### PR TITLE
Tidy repository

### DIFF
--- a/setoid.ipkg
+++ b/setoid.ipkg
@@ -18,16 +18,16 @@ depends
 
 -- modules to install
 modules
-  = Data.Setoid
+  = Data.Fun.Nary
+  , Data.Setoid
   , Data.Setoid.Definition
   , Data.Setoid.Either
+  , Data.Setoid.List
   , Data.Setoid.Pair
   , Data.Setoid.Vect
   , Data.Setoid.Vect.Functional
   , Data.Setoid.Vect.Inductive
-  , Data.Setoid.List
   , Syntax.PreorderReasoning.Setoid
-  , Data.Fun.Nary
 
 -- main file (i.e. file to load at REPL)
 -- main =

--- a/src/Setoid.idr
+++ b/src/Setoid.idr
@@ -1,1 +1,0 @@
-module Setoid


### PR DESCRIPTION
A small number of changes to simplify future maintenance.

- Remove the empty and unreferenced `Setoid` module.
- Sort the list of modules in the package manifest.

This allows for a basic [pre-commit hook](https://gist.github.com/yellowsquid/8d006bb7eaa8e772f00668fa1df9d3fd) to ensure all modules are included in the manifest, and that they all compile successfully.